### PR TITLE
Small Python 3.x update

### DIFF
--- a/rotation_forest/rotation_forest.py
+++ b/rotation_forest/rotation_forest.py
@@ -12,7 +12,7 @@ from _exceptions import NotFittedError
 def random_feature_subsets(array, batch_size, random_state=1234):
     """ Generate K subsets of the features in X """
     random_state = check_random_state(random_state)
-    features = range(array.shape[1])
+    features = list(range(array.shape[1]))
     random_state.shuffle(features)
     for batch in gen_batches(len(features), batch_size):
         yield features[batch]

--- a/rotation_forest/rotation_forest.py
+++ b/rotation_forest/rotation_forest.py
@@ -5,7 +5,8 @@ from sklearn.tree._tree import DTYPE
 from sklearn.ensemble.forest import ForestClassifier
 from sklearn.utils import resample, gen_batches, check_random_state
 from sklearn.utils.extmath import fast_dot
-from sklearn.decomposition import PCA, RandomizedPCA
+from sklearn.decomposition import PCA
+from sklearn.decomposition import PCA as RandomizedPCA
 
 from _exceptions import NotFittedError
 
@@ -59,7 +60,7 @@ class RotationTreeClassifier(DecisionTreeClassifier):
     def pca_algorithm(self):
         """ Deterimine PCA algorithm to use. """
         if self.rotation_algo == 'randomized':
-            return RandomizedPCA(random_state=self.random_state)
+            return RandomizedPCA(random_state=self.random_state, svd_solver='randomized')
         elif self.rotation_algo == 'pca':
             return PCA()
         else:


### PR DESCRIPTION
The `range()` builtin no longer returns a list in Python 3.x. Would need to cast in order to modify. Cast should be fine in Python 2.x also.